### PR TITLE
Responsive and ncurses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,6 @@ pkg_check_modules(CURL libcurl REQUIRED)
 set(CURSES_NEED_NCURSES TRUE)
 set(CURSES_NEED_WIDE TRUE)
 
-#pkg_check_modules(CURSES libncursesw REQUIRED)
 find_package(Curses REQUIRED)
 #include(FindNcursesw)
 #find_package(Ncursesw REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,19 @@
 cmake_minimum_required(VERSION 3.20)
 project(cctop)
-set(CMAKE_CXX_STANDARD 14)
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+#set(CURSES_INCLUDE_PATH "/opt/homebrew/ncurses/include")
+
+set(CMAKE_CXX_STANDARD 17)
 
 if (UNIX AND NOT APPLE)
     set(LINUX TRUE)
- endif()
+else ()
+    set(CMAKE_PREFIX_PATH "/opt/homebrew/opt/ncurses")
+endif ()
 
-
-add_executable (cctop
+add_executable(cctop
+        cctop.h
         main.cpp
         lib/Console.cpp lib/Console.h
         lib/Parser.cpp lib/Parser.h
@@ -17,16 +23,39 @@ add_executable (cctop
         macos/Platform.cpp macos/Platform.h
         macos/Processor.cpp macos/Processor.h
         macos/VirtualMemory.cpp macos/VirtualMemory.h
-        macos/ProcessList.cpp macos/ProcessList.h macos/Battery.cpp macos/Battery.h lib/Options.cpp lib/Options.h lib/Help.cpp lib/Help.h cctop.h common/Docker.cpp common/Docker.h)
+        macos/ProcessList.cpp macos/ProcessList.h
+        macos/Battery.cpp macos/Battery.h
+        lib/Options.cpp lib/Options.h
+        lib/Help.cpp lib/Help.h
+        common/Docker.cpp common/Docker.h
+        common/Debug.cpp common/Debug.h)
 
 include(FindPkgConfig)
 pkg_check_modules(CURL libcurl REQUIRED)
+
+set(CURSES_NEED_NCURSES TRUE)
+set(CURSES_NEED_WIDE TRUE)
+
+#pkg_check_modules(CURSES libncursesw REQUIRED)
+find_package(Curses REQUIRED)
+#include(FindNcursesw)
+#find_package(Ncursesw REQUIRED)
+#find_library(NCURSESW NAMES "ncursesw" PATHS "/opt/homebrew/opt/ncurses/lib")
+#message(FATAL_ERROR ${NCURSESW})
+#find_package(Ncursesw)
+
+#    message(FATAL_ERROR "not found ncursesw")
+#if (NOT NCURSESW_FOUND)
+#    message(FATAL_ERROR "not found ncursesw")
+#endif ()
+
 include_directories(
-        macos ${CURL_INCLUDE_DIRS}
+        ${CURL_INCLUDE_DIRS} ${CURSES_INCLUDE_DIRS} macos
 )
 target_link_libraries(
         cctop
         ${CURL_LIBRARIES}
+        ${CURSES_LIBRARIES}
 )
 
 if (APPLE)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # cctop
 
+## Building
+
+### MacOS
+
+This program is built with cmake.  We use the cmake from homebrew, setting the 
+path in the CLion IDE settings.  We also installed ncurses using homebrew and 
+set the paths in CMakeLists.txt to use that.  The reason is that the curses
+that comes with XCode and MacOS is very old and doesn't support wide characters.
+
+What we really want is libncursesw.dylib (w on the end means wide character support).
+
 ## WIDE CHARACTERS (UTF_16)
 ```c++
     //    0x2581 ▁

--- a/cctop.h
+++ b/cctop.h
@@ -10,6 +10,11 @@
 // debug print to this file:
 #define DEBUG_LOGFILE "/tmp/cctop.log"
 
+#ifdef USE_NCURSES
+#define _XOPEN_SOURCE_EXTENDED
+#include <ncurses.h>
+#endif
+
 #include "common/Debug.h"
 
 #include "lib/Console.h"
@@ -24,6 +29,6 @@
 #include "macos/ProcessList.h"
 #include "macos/Battery.h"
 
-const int MIN_WIDTH = 99, MIN_HEIGHT = 48;
+const int MIN_WIDTH = 96, MIN_HEIGHT = 30;
 
 #endif //CCTOP_CCTOP_H

--- a/cctop.h
+++ b/cctop.h
@@ -1,7 +1,16 @@
 #ifndef CCTOP_CCTOP_H
 #define CCTOP_CCTOP_H
 
-#define DEBUG 0
+#define USE_NCURSES
+//#undef USE_NCURSES
+
+// define VERBOSE to enable debug printing
+#define VERBOSE
+//#undef VERBOSE
+// debug print to this file:
+#define DEBUG_LOGFILE "/tmp/cctop.log"
+
+#include "common/Debug.h"
 
 #include "lib/Console.h"
 #include "lib/Options.h"

--- a/cmake/Modules/FindNcursesw.cmake
+++ b/cmake/Modules/FindNcursesw.cmake
@@ -1,0 +1,204 @@
+#.rst:
+# FindNcursesw
+# ------------
+#
+# Find the ncursesw (wide ncurses) include file and library.
+#
+# Based on FindCurses.cmake which comes with CMake.
+#
+# Checks for ncursesw first. If not found, it then executes the
+# regular old FindCurses.cmake to look for for ncurses (or curses).
+#
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines the following variables:
+#
+# ``CURSES_FOUND``
+#   True if curses is found.
+# ``NCURSESW_FOUND``
+#   True if ncursesw is found.
+# ``CURSES_INCLUDE_DIRS``
+#   The include directories needed to use Curses.
+# ``CURSES_LIBRARIES``
+#   The libraries needed to use Curses.
+# ``CURSES_HAVE_CURSES_H``
+#   True if curses.h is available.
+# ``CURSES_HAVE_NCURSES_H``
+#   True if ncurses.h is available.
+# ``CURSES_HAVE_NCURSES_NCURSES_H``
+#   True if ``ncurses/ncurses.h`` is available.
+# ``CURSES_HAVE_NCURSES_CURSES_H``
+#   True if ``ncurses/curses.h`` is available.
+# ``CURSES_HAVE_NCURSESW_NCURSES_H``
+#   True if ``ncursesw/ncurses.h`` is available.
+# ``CURSES_HAVE_NCURSESW_CURSES_H``
+#   True if ``ncursesw/curses.h`` is available.
+#
+# Set ``CURSES_NEED_NCURSES`` to ``TRUE`` before the
+# ``find_package(Ncursesw)`` call if NCurses functionality is required.
+#
+#=============================================================================
+# Copyright 2001-2014 Kitware, Inc.
+# modifications: Copyright 2015 kahrl <kahrl@gmx.net>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the names of Kitware, Inc., the Insight Software Consortium,
+#   nor the names of their contributors may be used to endorse or promote
+#   products derived from this software without specific prior written
+#   permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# ------------------------------------------------------------------------------
+#
+# The above copyright and license notice applies to distributions of
+# CMake in source and binary form.  Some source files contain additional
+# notices of original copyright by their contributors; see each source
+# for details.  Third-party software packages supplied with CMake under
+# compatible licenses provide their own copyright notices documented in
+# corresponding subdirectories.
+#
+# ------------------------------------------------------------------------------
+#
+# CMake was initially developed by Kitware with the following sponsorship:
+#
+#  * National Library of Medicine at the National Institutes of Health
+#    as part of the Insight Segmentation and Registration Toolkit (ITK).
+#
+#  * US National Labs (Los Alamos, Livermore, Sandia) ASC Parallel
+#    Visualization Initiative.
+#
+#  * National Alliance for Medical Image Computing (NAMIC) is funded by the
+#    National Institutes of Health through the NIH Roadmap for Medical Research,
+#    Grant U54 EB005149.
+#
+#  * Kitware, Inc.
+#=============================================================================
+
+include(CheckLibraryExists)
+
+find_library(CURSES_NCURSESW_LIBRARY NAMES ncursesw
+        DOC "Path to libncursesw.so or .lib or .a")
+
+set(CURSES_USE_NCURSES FALSE)
+set(CURSES_USE_NCURSESW FALSE)
+
+if (CURSES_NCURSESW_LIBRARY)
+    set(CURSES_USE_NCURSES TRUE)
+    set(CURSES_USE_NCURSESW TRUE)
+endif ()
+
+if (CURSES_USE_NCURSESW)
+    get_filename_component(_cursesLibDir "${CURSES_NCURSESW_LIBRARY}" PATH)
+    get_filename_component(_cursesParentDir "${_cursesLibDir}" PATH)
+
+    find_path(CURSES_INCLUDE_PATH
+            NAMES ncursesw/ncurses.h ncursesw/curses.h ncurses.h curses.h
+            HINTS "${_cursesParentDir}/include"
+            )
+
+    # Previous versions of FindCurses provided these values.
+    if (NOT DEFINED CURSES_LIBRARY)
+        set(CURSES_LIBRARY "${CURSES_NCURSESW_LIBRARY}")
+    endif ()
+
+    CHECK_LIBRARY_EXISTS("${CURSES_NCURSESW_LIBRARY}"
+            cbreak "" CURSES_NCURSESW_HAS_CBREAK)
+    if (NOT CURSES_NCURSESW_HAS_CBREAK)
+        find_library(CURSES_EXTRA_LIBRARY tinfo HINTS "${_cursesLibDir}"
+                DOC "Path to libtinfo.so or .lib or .a")
+        find_library(CURSES_EXTRA_LIBRARY tinfo)
+    endif ()
+
+    # Report whether each possible header name exists in the include directory.
+    if (NOT DEFINED CURSES_HAVE_NCURSESW_NCURSES_H)
+        if (EXISTS "${CURSES_INCLUDE_PATH}/ncursesw/ncurses.h")
+            set(CURSES_HAVE_NCURSESW_NCURSES_H "${CURSES_INCLUDE_PATH}/ncursesw/ncurses.h")
+        else ()
+            set(CURSES_HAVE_NCURSESW_NCURSES_H "CURSES_HAVE_NCURSESW_NCURSES_H-NOTFOUND")
+        endif ()
+    endif ()
+    if (NOT DEFINED CURSES_HAVE_NCURSESW_CURSES_H)
+        if (EXISTS "${CURSES_INCLUDE_PATH}/ncursesw/curses.h")
+            set(CURSES_HAVE_NCURSESW_CURSES_H "${CURSES_INCLUDE_PATH}/ncursesw/curses.h")
+        else ()
+            set(CURSES_HAVE_NCURSESW_CURSES_H "CURSES_HAVE_NCURSESW_CURSES_H-NOTFOUND")
+        endif ()
+    endif ()
+    if (NOT DEFINED CURSES_HAVE_NCURSES_H)
+        if (EXISTS "${CURSES_INCLUDE_PATH}/ncurses.h")
+            set(CURSES_HAVE_NCURSES_H "${CURSES_INCLUDE_PATH}/ncurses.h")
+        else ()
+            set(CURSES_HAVE_NCURSES_H "CURSES_HAVE_NCURSES_H-NOTFOUND")
+        endif ()
+    endif ()
+    if (NOT DEFINED CURSES_HAVE_CURSES_H)
+        if (EXISTS "${CURSES_INCLUDE_PATH}/curses.h")
+            set(CURSES_HAVE_CURSES_H "${CURSES_INCLUDE_PATH}/curses.h")
+        else ()
+            set(CURSES_HAVE_CURSES_H "CURSES_HAVE_CURSES_H-NOTFOUND")
+        endif ()
+    endif ()
+
+
+    find_library(CURSES_FORM_LIBRARY form HINTS "${_cursesLibDir}"
+            DOC "Path to libform.so or .lib or .a")
+    find_library(CURSES_FORM_LIBRARY form)
+
+    # Need to provide the *_LIBRARIES
+    set(CURSES_LIBRARIES ${CURSES_LIBRARY})
+
+    if (CURSES_EXTRA_LIBRARY)
+        set(CURSES_LIBRARIES ${CURSES_LIBRARIES} ${CURSES_EXTRA_LIBRARY})
+    endif ()
+
+    if (CURSES_FORM_LIBRARY)
+        set(CURSES_LIBRARIES ${CURSES_LIBRARIES} ${CURSES_FORM_LIBRARY})
+    endif ()
+
+    # Provide the *_INCLUDE_DIRS result.
+    set(CURSES_INCLUDE_DIRS ${CURSES_INCLUDE_PATH})
+    set(CURSES_INCLUDE_DIR ${CURSES_INCLUDE_PATH}) # compatibility
+
+    # handle the QUIETLY and REQUIRED arguments and set CURSES_FOUND to TRUE if
+    # all listed variables are TRUE
+    include(FindPackageHandleStandardArgs)
+    FIND_PACKAGE_HANDLE_STANDARD_ARGS(Ncursesw DEFAULT_MSG
+            CURSES_LIBRARY CURSES_INCLUDE_PATH)
+    set(CURSES_FOUND ${NCURSESW_FOUND})
+
+else ()
+    find_package(Curses)
+    set(NCURSESW_FOUND FALSE)
+endif ()
+
+mark_as_advanced(
+        CURSES_INCLUDE_PATH
+        CURSES_CURSES_LIBRARY
+        CURSES_NCURSES_LIBRARY
+        CURSES_NCURSESW_LIBRARY
+        CURSES_EXTRA_LIBRARY
+        CURSES_FORM_LIBRARY
+)

--- a/common/Debug.cpp
+++ b/common/Debug.cpp
@@ -1,0 +1,56 @@
+//
+// Created by Michael Schwartz on 12/15/21.
+//
+
+#include "../cctop.h"
+#include "Debug.h"
+#include <cstdarg>
+
+Debug::Debug() {
+#ifdef VERBOSE
+    logfile = fopen(DEBUG_LOGFILE, "w");
+    fprintf(logfile, "\nBegin DEBUG log:\n");
+    fflush(logfile);
+#endif
+}
+
+Debug::~Debug() {
+#ifdef VERBOSE
+    fclose(logfile);
+    logfile = nullptr;
+#endif
+}
+
+void Debug::log(const char *fmt, ...) {
+#ifdef VERBOSE
+    va_list ap;
+
+    char buffer[1024];
+    va_start(ap, fmt);
+    vsprintf(buffer, fmt, ap);
+    va_end(ap);
+
+    if (logfile != nullptr) {
+        fprintf(logfile, "%s\n", buffer);
+        fflush(logfile);
+    }
+#endif
+}
+
+void Debug::printw(const wchar_t *fmt, ...) {
+#ifdef VERBOSE
+    va_list ap;
+
+    wchar_t buffer[1024];
+    va_start(ap, fmt);
+    vswprintf(buffer, 1024, fmt, ap);
+    va_end(ap);
+
+    if (logfile != nullptr) {
+        fwprintf(logfile, L"%ls\n", buffer);
+        fflush(logfile);
+    }
+#endif
+}
+
+Debug debug;

--- a/common/Debug.cpp
+++ b/common/Debug.cpp
@@ -31,7 +31,7 @@ void Debug::log(const char *fmt, ...) {
     va_end(ap);
 
     if (logfile != nullptr) {
-        fprintf(logfile, "%s\n", buffer);
+        fprintf(logfile, "%s", buffer);
         fflush(logfile);
     }
 #endif
@@ -47,7 +47,7 @@ void Debug::printw(const wchar_t *fmt, ...) {
     va_end(ap);
 
     if (logfile != nullptr) {
-        fwprintf(logfile, L"%ls\n", buffer);
+        fwprintf(logfile, L"%ls", buffer);
         fflush(logfile);
     }
 #endif

--- a/common/Debug.h
+++ b/common/Debug.h
@@ -1,0 +1,24 @@
+//
+// Created by Michael Schwartz on 12/15/21.
+//
+
+#ifndef CCTOP_DEBUG_H
+#define CCTOP_DEBUG_H
+
+#include <cstdio>
+
+class Debug {
+public:
+    Debug();
+    ~Debug();
+public:
+    void log(const char *fmt, ...);
+    void printw(const wchar_t *fmt, ...);
+protected:
+    FILE *logfile{nullptr};
+
+};
+
+extern Debug debug;
+
+#endif //CCTOP_DEBUG_H

--- a/lib/Console.h
+++ b/lib/Console.h
@@ -24,6 +24,7 @@
 #ifndef C_CONSOLE_H
 #define C_CONSOLE_H
 
+#define _XOPEN_SOURCE_EXTENDED
 #include <cstdint>
 #include <cstdio>
 #include <sys/ioctl.h>
@@ -37,6 +38,7 @@ public:
 
 private:
     bool aborting{}, pad{};
+    int current_pair{-1};
 
     uint16_t row{}, col{}; // cursor location
 
@@ -67,11 +69,12 @@ public:
     // Call to update Console's notion of width and height.
     // Also clears the screen/window.
     void resize();
+    void update();
 
 public:
     void raw(bool on = true);
 
-    bool getch(int *c, bool timeout = false);
+    bool read_character(int *c, bool timeout = false);
 
 public:
     // enable/disable cursor
@@ -87,7 +90,7 @@ public:
     void clear_eol();
 
     // address cursor
-    void moveTo(uint16_t row, uint16_t col);
+    void moveTo(uint16_t r, uint16_t c);
 
     // printf style output to terminal
     void print(const char *fmt, ...);
@@ -99,10 +102,10 @@ public:
     void inverseln(const char *fmt, ...);
 
     // wprintf style output to terminal
-    void wprint(const wchar_t *fmt, ...);
+    void wprintf(const wchar_t *fmt, ...);
 
     // printf style output to terminal, with newline
-    void wprintln(const wchar_t *fmt, ...);
+    void wprintfln(const wchar_t *fmt, ...);
     // print line inverse, with newline
 
     // emit a newline
@@ -132,11 +135,11 @@ public:
     // turn on/off inverse
     void mode_inverse(bool on = true);
 
-    // turn on/off concealed
-    void mode_concealed(bool on = true);
-
-private:
-    void set_color(uint8_t color, bool on);
+public:
+    void default_colors();
+    void set_colors(uint8_t fg, uint8_t bg);
+    void set_foreground(uint8_t color);
+    void set_background(uint8_t color);
 
 public:
     // reset foreground/background colors to default

--- a/lib/Console.h
+++ b/lib/Console.h
@@ -40,7 +40,7 @@ private:
     bool aborting{}, pad{};
     int current_pair{-1};
 
-    uint16_t row{}, col{}; // cursor location
+    uint16_t current_row{0}, current_column{0};
 
     // modes
     bool bold{false},
@@ -70,6 +70,8 @@ public:
     // Also clears the screen/window.
     void resize();
     void update();
+    uint16_t cursor_row();
+    uint16_t cursor_column();
 
 public:
     void raw(bool on = true);

--- a/lib/Help.cpp
+++ b/lib/Help.cpp
@@ -8,24 +8,25 @@ static const char *true_false(bool t) {
 
 void Help::show() {
     if (options.showHelp) {
-        int margin = 2, padding = 2;
-        console.window(5, margin + 1,
-                       console.width - margin - margin, 14,
-                       "HELP");
-        int row = margin + 1 + padding,
-                col = margin + 1 + padding;
+        int margin = 4, padding = 2,
+                row = margin, col = margin,
+                height = 15;
 
+        console.window(row, margin,
+                       console.width - margin - margin, height,
+                       "HELP");
 //        console.moveTo(row++, col);
 //        console.print("HELP");
-        row++;
-        row++;
+        row += padding;
+        col += padding;
 
         console.moveTo(row++, col);
         console.print("C %-48.48s %s", "toggles condensed CPU display", true_false(options.condenseCPU));
         console.moveTo(row++, col);
         console.print("M %-48.48s %s", "toggles condensed Memory display", true_false(options.condenseMemory));
         console.moveTo(row++, col);
-        console.print("V %-48.48s %s", "toggles condensed Virtual Memory display", true_false(options.condenseVirtualMemory));
+        console.print("V %-48.48s %s", "toggles condensed Virtual Memory display",
+                      true_false(options.condenseVirtualMemory));
         console.moveTo(row++, col);
         console.print("D %-48.48s %s", "toggles condensed Disk Activity display", true_false(options.condenseDisk));
         console.moveTo(row++, col);

--- a/macos/Disk.cpp
+++ b/macos/Disk.cpp
@@ -369,7 +369,7 @@ uint16_t Disk::update() {
     return num_devices;
 }
 
-uint16_t Disk::print() {
+uint16_t Disk::print(bool newline) {
     uint16_t count = 0;
 
     console.inverseln("  %-16s %13s %13s %13s %13s %13s", "[D]ISK ACTIVITY",
@@ -385,6 +385,10 @@ uint16_t Disk::print() {
                             stats->total_transfers);
             count++;
         }
+    }
+    if (newline) {
+        console.newline();
+        count++;
     }
     return count;
 }

--- a/macos/Disk.h
+++ b/macos/Disk.h
@@ -76,7 +76,7 @@ public:
 public:
   uint16_t update();
 
-  uint16_t print();
+  uint16_t print(bool newline);
 };
 
 extern Disk disk;

--- a/macos/Memory.cpp
+++ b/macos/Memory.cpp
@@ -95,7 +95,7 @@ void Memory::update() {
     delta->swap_free = current->swap_free - last->swap_free;
 }
 
-uint16_t Memory::print() const {
+uint16_t Memory::print(bool newline) const {
     uint16_t count = 0;
     console.inverseln("%-12s %9s %9s %9s %9s %9s",
                       "  [M]EMORY", "Total", "Used", "Free", "Wired", "Cached");
@@ -115,10 +115,14 @@ uint16_t Memory::print() const {
         console.println("  %-12s %'9lld %'9lld %'9lld", "Swap", this->current.swap_size / 1024 / 1024,
                         this->current.swap_used / 1024 / 1024, this->current.swap_free / 1024 / 1024);
     }
+    if (newline) {
+        console.newline();
+        count++;
+    }
     return count; // # lines printed
 }
 
-uint16_t Memory::printVirtualMemory() {
+uint16_t Memory::printVirtualMemory(bool newline) {
     uint16_t count = 0;
 
     console.inverseln("  %-16s %19s %22s", "[V]IRTUAL MEMORY", "  IN Current OUT  ", "  IN Aggregate OUT ");
@@ -135,6 +139,10 @@ uint16_t Memory::printVirtualMemory() {
                         this->delta.swapouts / 1024 / 1024,
                         this->current.swapins / 1024 / 1024,
                         this->current.swapouts / 10924 / 1024);
+        count++;
+    }
+    if (newline) {
+        console.newline();
         count++;
     }
     return count;

--- a/macos/Memory.h
+++ b/macos/Memory.h
@@ -64,9 +64,9 @@ public:
     void update();
 
     // print memory stats unless test is set
-    uint16_t print() const;
+    uint16_t print(bool newline) const;
 
-    uint16_t printVirtualMemory();
+    uint16_t printVirtualMemory(bool newline);
 };
 
 extern Memory memory;

--- a/macos/Network.cpp
+++ b/macos/Network.cpp
@@ -132,10 +132,15 @@ void Network::update() {
     }
 }
 
-uint16_t Network::print() {
+uint16_t Network::print(bool newline) {
     uint16_t count = 0;
-    console.inverseln("  %-10s %13s %13s %13s %13s %13s %13s", "[N]ETWORK", "Read (B/s)", "Write (B/s)", "RX Packets",
-                      "TX Packets", "Total RX", "Total TX");
+    if (console.width < 98) {
+        console.inverseln("  %-10s %13s %13s", "[N]ETWORK", "Read (B/s)", "Write (B/s)", "RX Packets");
+    } else {
+        console.inverseln("  %-10s %13s %13s %13s %13s %13s %13s", "[N]ETWORK", "Read (B/s)", "Write (B/s)",
+                          "RX Packets",
+                          "TX Packets", "Total RX", "Total TX");
+    }
     count++;
 
     if (!options.condenseNetwork) {
@@ -147,18 +152,30 @@ uint16_t Network::print() {
             }
             auto *c = (Interface *) this->current[name];
             if (i->flags & IFF_UP && this->current[i->name]->packetsIn) {
-                console.println("  %-10s %'13lld %'13lld %'13lld %'13lld %'13lld %'13lld",
-                                i->name.c_str(),
-                                i->bytesIn,
-                                i->bytesOut,
-                                i->packetsIn,
-                                i->packetsOut,
-                                c->packetsIn,
-                                c->packetsOut
-                );
+                if (console.width < 98) {
+                    console.println("  %-10s %'13lld %'13lld",
+                                    i->name.c_str(),
+                                    i->bytesIn,
+                                    i->bytesOut
+                    );
+                } else {
+                    console.println("  %-10s %'13lld %'13lld %'13lld %'13lld %'13lld %'13lld",
+                                    i->name.c_str(),
+                                    i->bytesIn,
+                                    i->bytesOut,
+                                    i->packetsIn,
+                                    i->packetsOut,
+                                    c->packetsIn,
+                                    c->packetsOut
+                    );
+                }
                 count++;
             }
         }
+    }
+    if (newline) {
+        console.newline();
+        count++;
     }
     return count;
 }

--- a/macos/Network.h
+++ b/macos/Network.h
@@ -61,7 +61,7 @@ public:
   void update();
 
   // print network stats, unless test is set,  return # lines (would be) printed
-  uint16_t print();
+  uint16_t print(bool newline);
 };
 
 extern Network network;

--- a/macos/Platform.cpp
+++ b/macos/Platform.cpp
@@ -163,7 +163,7 @@ void Platform::update() {
     this->num_processes = length / sizeof(kinfo_proc);
 }
 
-uint16_t Platform::print() {
+uint16_t Platform::print(bool newline) {
     uint16_t count = 0;
 
     this->uptime = get_uptime();
@@ -181,15 +181,16 @@ uint16_t Platform::print() {
     uint64_t hours = current_uptime / secs_per_hour;
     uint64_t minutes = (current_uptime - hours * secs_per_hour) / 60;
 
-    const int width = console.width ? console.width : 80;
-    char out[width + 1];
-    sprintf(out, " cctop/%llu [%s/%s %s]", options.read_timeout/1000, hostname, sysname, release);
-    size_t fill = width - strlen(out) - strlen(s) - 1;
+//    const int width = console.width ? console.width : 80;
+    char out[console.width + 1];
+    sprintf(out, " cctop/%llu [%s/%s %s] %d x %d", options.read_timeout / 1000, hostname, sysname, release, console.width, console.height);
+    size_t fill = console.width - strlen(out) - strlen(s) - 2;
     char *ptr = &out[strlen(out)];
     while (fill > 0) {
         *ptr++ = ' ';
         fill--;
     }
+    *ptr = '\0';
     strcat(ptr, s);
     console.inverseln(out);
     count++;
@@ -225,7 +226,11 @@ uint16_t Platform::print() {
     }
     console.clear_eol();
     console.newline();
-    count++;
+
+    if (newline) {
+        console.newline();
+        count++;
+    }
     return count;
 }
 

--- a/macos/Platform.h
+++ b/macos/Platform.h
@@ -65,7 +65,7 @@ public:
 public:
     void update();
 
-    uint16_t print();
+    uint16_t print(bool newline);
 };
 
 extern Platform platform;

--- a/macos/ProcessList.cpp
+++ b/macos/ProcessList.cpp
@@ -155,7 +155,7 @@ uint16_t ProcessList::print() {
         auto pass = username(p->ruid);
         auto grp = groupname(p->rgid);
 
-        console.println(" %6d %6.1f %-16.16s %-32.32s", p->pid, p->pct_cpu * 10000, pass, p->name);
+        console.println(" %6d %6.1f %-16.16s %-32.32s", p->pid, p->pct_cpu * 1000, pass, p->name);
         count++;
         if (options.condenseProcesses) {
             break;

--- a/macos/ProcessList.cpp
+++ b/macos/ProcessList.cpp
@@ -115,7 +115,7 @@ static bool cmp(Process *a, Process *b) {
     return a->pct_cpu > b->pct_cpu;
 }
 
-uint16_t ProcessList::print() {
+uint16_t ProcessList::print(bool newline) {
     uint16_t count = 0;
     std::vector<Process *> sorted, to_remove;
     // Loop through our map of processes (pid is key, value is struct).
@@ -148,6 +148,7 @@ uint16_t ProcessList::print() {
     int printed = 0;
     console.inverseln(" %6.6s %6.6s %-16.16s %-32.32s", "[P]ID", "CPU%", "USER", "NAME");
     count++;
+    int lines = console.height - console.cursor_row() -2;
     for (auto &it: sorted) {
         auto p = it;
 //        if (p->ppid > 1) continue;
@@ -155,15 +156,23 @@ uint16_t ProcessList::print() {
         auto pass = username(p->ruid);
         auto grp = groupname(p->rgid);
 
+        if (!strcmp(p->name, "cctop")) {
+            console.mode_bold(true);
+        }
         console.println(" %6d %6.1f %-16.16s %-32.32s", p->pid, p->pct_cpu * 1000, pass, p->name);
+        console.mode_bold(false);
         count++;
         if (options.condenseProcesses) {
             break;
         }
-        if (printed > 10) break;
+        if (printed > lines) break;
     }
     console.println("  %ld processes", sorted.size());
     count++;
+    if (newline) {
+        console.newline();
+        count++;
+    }
     return count;
 }
 

--- a/macos/ProcessList.h
+++ b/macos/ProcessList.h
@@ -71,7 +71,7 @@ public:
 public:
     void update();
 
-    uint16_t print();
+    uint16_t print(bool newline);
 
 protected:
     int64_t touched{0};

--- a/macos/Processor.cpp
+++ b/macos/Processor.cpp
@@ -19,6 +19,7 @@
  */
 #include "../cctop.h"
 #include <mach/mach_host.h>
+#include <unistd.h>
 
 //    2581 ▁
 //    2582 ▂
@@ -44,6 +45,7 @@ struct dots {
 };
 
 static void renderColor(int ndx) {
+#ifdef USE_NCURSES
     switch (ndx) {
         case 0:
             console.fg_yellow();
@@ -75,9 +77,53 @@ static void renderColor(int ndx) {
         default:
             break;
     }
+#else
+    switch (ndx) {
+        case 0:
+            console.fg_yellow();
+            break;
+        case 1:
+            console.fg_cyan();
+            break;
+        case 2:
+            console.fg_cyan();
+            break;
+        case 3:
+            console.mode_bold();
+            console.fg_blue();
+            break;
+        case 4:
+            console.fg_magenta();
+            break;
+        case 5:
+            console.fg_magenta();
+            console.mode_bold();
+            break;
+        case 6:
+            console.fg_red();
+            break;
+        case 7:
+            console.fg_red();
+            console.mode_bold();
+            break;
+        default:
+            break;
+    }
+#endif
 }
 
 static void renderDot(int ndx) {
+#ifdef USE_NCURSES
+    if (ndx >= 0 && ndx <= 7) {
+        renderColor(ndx);
+        console.wprintf(L"%lc", dots[ndx].ch);
+//        console.fg_rgb(255, 255, 255);
+//        console.fg_rgb(dots[ndx].r, dots[ndx].g, dots[ndx].b);
+        console.mode_clear();
+    } else {
+        console.print(" ");
+    }
+#else
     if (ndx >= 0 && ndx <= 7) {
         renderColor(ndx);
 //        console.fg_rgb(dots[ndx].r, dots[ndx].g, dots[ndx].b);
@@ -87,6 +133,7 @@ static void renderDot(int ndx) {
     } else {
         console.print(" ");
     }
+#endif
 }
 
 CPU::CPU() {
@@ -137,7 +184,8 @@ void CPU::print() {
     history[CPU_HISTORY_SIZE - 1] = ndx;
 
     renderColor(ndx);
-    console.wprint(L"  %-6s %6.1f%% %6.1f%% %6.1f%% %6.1f%% %6.1f%% ",
+
+    console.wprintf(L"  %-6s %6.1f%% %6.1f%% %6.1f%% %6.1f%% %6.1f%% ",
                    this->name,
                    _use,
                    _user,
@@ -170,11 +218,11 @@ void CPU::print() {
 
     for (wchar_t i: history) {
         renderDot(i);
-//        console.wprint(L"%lc", i);
+//        console.wprintf(L"%lc", i);
     }
     console.newline();
 //    if (total != 0) {
-//        console.wprintln(L" %lc", c);
+//        console.wprintfln(L" %lc", c);
 //    }
 }
 

--- a/macos/Processor.h
+++ b/macos/Processor.h
@@ -37,6 +37,7 @@ struct CPU {
     void diff(CPU *newer, CPU *older);
 
     void print();
+    void addHistory(int h);
 };
 
 class Processor {
@@ -57,7 +58,7 @@ public:
 
     void update();
 
-    uint16_t print();
+    uint16_t print(bool newline);
 };
 
 extern Processor processor;

--- a/macos/VirtualMemory.h
+++ b/macos/VirtualMemory.h
@@ -37,7 +37,7 @@ public:
   void read(VMStats *stats);
   void copy(VMStats *dst, VMStats *src);
   void update();
-  uint16_t print(bool test);
+  uint16_t print(bool newline);
 };
 
 extern VirtualMemory virtual_memory;

--- a/main.cpp
+++ b/main.cpp
@@ -1,21 +1,25 @@
 #include "cctop.h"
 #include <clocale>
+#include <unistd.h>
 
 
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "EndlessLoop"
 
 void resize_help() {
+#if !debug
     console.clear();
     console.println("Window is %dx%d and needs to be at least %dx%d]",
                     console.width, console.height,
                     MIN_WIDTH, MIN_HEIGHT);
+#endif
 }
 
 int required_lines = -1;
 
 uint16_t loop() {
     if (console.width < MIN_WIDTH || console.height < MIN_HEIGHT) {
+        debug.log("resize_help");
         resize_help();
         return 0;
     }
@@ -28,9 +32,10 @@ uint16_t loop() {
     network.update();
     processList.update();
 
-    console.moveTo(1, 1);
+    console.moveTo(0, 0);
     lines += platform.print();
-    console.newline();
+//    console.newline();
+//    console.update();
     lines++;
 
     if (!options.showHelp) {
@@ -73,7 +78,7 @@ uint16_t loop() {
     Help::show();
     lines++;
     console.print("%d/%d lines %dx%d\n", lines, required_lines, console.width, console.height);
-    console.clear(true);
+//    console.clear(true);
     return lines;
 }
 
@@ -131,7 +136,8 @@ int main() {
     loop();
     for (;;) {
         loop();
-        if (console.getch(&c, true)) {
+        console.update();
+        if (console.read_character(&c, true)) {
             options.process(c);
         }
     }

--- a/main.cpp
+++ b/main.cpp
@@ -2,7 +2,6 @@
 #include <clocale>
 #include <unistd.h>
 
-
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "EndlessLoop"
 
@@ -19,7 +18,7 @@ int required_lines = -1;
 
 uint16_t loop() {
     if (console.width < MIN_WIDTH || console.height < MIN_HEIGHT) {
-        debug.log("resize_help");
+//        debug.log("resize_help");
         resize_help();
         return 0;
     }
@@ -33,51 +32,40 @@ uint16_t loop() {
     processList.update();
 
     console.moveTo(0, 0);
-    lines += platform.print();
-//    console.newline();
-//    console.update();
-    lines++;
+    console.mode_clear();
 
+#ifndef USE_NCURSES
     if (!options.showHelp) {
-        lines += processor.print();
-        if (lines < required_lines && !options.condenseMain) {
-            console.newline();
-            lines++;
+#endif
+    bool condense = options.condenseMain;
+    options.condenseCPU = false;
+    if (console.height < 40) {
+        options.condenseCPU = true;
+        if (console.height < 35) {
+            condense = true;
         }
-
-        lines += memory.print();
-        if (lines < required_lines && !options.condenseMain) {
-            console.newline();
-            lines++;
-        }
-        lines += memory.printVirtualMemory();
-        if (lines < required_lines && !options.condenseMain) {
-            console.newline();
-            lines++;
-        }
-
-
-        lines += disk.print();
-        if (lines < required_lines && !options.condenseMain) {
-            console.newline();
-            lines++;
-        }
-
-        lines += network.print();
-        if (lines < required_lines && !options.condenseMain) {
-            console.newline();
-            lines++;
-        }
-
-        lines += processList.print();
     }
+    else if (console.height < 45) {
+        condense = true;
+    }
+//    debug.log("window %d x %d %d\n", console.width, console.height, condense);
+    lines += platform.print(!condense);
+    lines += processor.print(!condense);
+    lines += memory.print(!condense);
+    lines += memory.printVirtualMemory(!condense);
+    lines += disk.print(!condense);
+    lines += network.print(!condense);
+    lines += processList.print(!condense);
+#ifndef USE_NCURSES
+    }
+#endif
 
     if (required_lines == -1) {
         required_lines = lines;
     }
     Help::show();
     lines++;
-    console.print("%d/%d lines %dx%d\n", lines, required_lines, console.width, console.height);
+//    console.print("%d/%d lines %dx%d\n", lines, required_lines, console.width, console.height);
 //    console.clear(true);
     return lines;
 }

--- a/tools/colortest.sh
+++ b/tools/colortest.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "Kitty version: $( ~/.local/kitty.app/bin/kitty --version )"
+#echo "Kitty version: $( /Applications/kitty.app/bin/kitty --version )"
 
 tmux_version=$(tmux -V)
 echo "tmux version: $tmux_version"
@@ -24,5 +24,3 @@ awk 'BEGIN{
     }
     printf "\n";
 }'
-echo 'Press CTRL+C to quit test.'
-sleep inf


### PR DESCRIPTION
Display is responsive  - it adjusts to terminal width and height, as window is resized.

Option (default) to use ncurses.

To use ncurses, set USE_NCURSES in cctop.h.  You cannot debug in CLion if ncurses is enabled.  The debugger terminal window is unknown to ncurses, and it panics/aborts.

Bolds cctop process in the process list.

Fixes:
* https://github.com/moduslabs/cctop/issues/12
* https://github.com/moduslabs/cctop/issues/2
