### PR TITLE
Gauges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .ccls-cache/
+*.o
+tools/widechars/widechars
 
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/cctop.h
+++ b/cctop.h
@@ -6,7 +6,7 @@
 
 // define VERBOSE to enable debug printing
 #define VERBOSE
-#undef VERBOSE
+//#undef VERBOSE
 // debug print to this file:
 #define DEBUG_LOGFILE "/tmp/cctop.log"
 

--- a/lib/Console.cpp
+++ b/lib/Console.cpp
@@ -800,13 +800,45 @@ void Console::wprintfln(const wchar_t *fmt, ...) {
     newline();
 }
 
-void Console::gauge(int aWidth, double pct, char fill) {
+void Console::gauge(int aWidth, double pct, int style) {
     print("[");
+    wchar_t fill = 0x25a0;
+
     int toFill = aWidth * pct / 100.,
             i;
-    for (i = 0; i < toFill; i++) {
-        print("%c", fill);
+
+    debug.log("pct: %.2f toFill %d\n", pct, toFill);
+    switch (style) {
+        case -1:
+            if (pct < .2) {
+                fg_red();
+            }
+            else if (pct < .5) {
+                fg_yellow();
+            }
+            else {
+                fg_green();
+            }
+            break;
+        case 0:
+        default:
+            break;
+        case 1:
+            if (pct > .5) {
+                fg_green();
+            }
+            else if (pct > .2) {
+                fg_yellow();
+            }
+            else {
+                fg_red();
+            }
+            break;
     }
+    for (i = 0; i < toFill; i++) {
+        wprintf(L"%lc", fill);
+    }
+    mode_clear();
     while (i < aWidth) {
         print(" ");
         i++;
@@ -860,6 +892,27 @@ void Console::newline(bool erase) {
     printf("\n");
     fflush(stdout);
 #endif
+}
+
+const char *Console::humanSize(uint64_t bytes, char *output, int maxSize) {
+    static char static_buf[200];
+
+    const char *suffix[] = {"B", "KB", "MB", "GB", "TB"};
+    char length = sizeof(suffix) / sizeof(suffix[0]);
+
+    int i = 0;
+    double dblBytes = bytes;
+
+    if (bytes > 1024) {
+        for (i = 0; (bytes / 1024) > 0 && i < length - 1; i++, bytes /= 1024)
+            dblBytes = bytes / 1024.0;
+    }
+
+    if (output == nullptr) {
+        output = static_buf;
+    }
+    snprintf(output, maxSize, "%.02lf %s", dblBytes, suffix[i]);
+    return output;
 }
 
 Console console;

--- a/lib/Console.h
+++ b/lib/Console.h
@@ -25,6 +25,7 @@
 #define C_CONSOLE_H
 
 #define _XOPEN_SOURCE_EXTENDED
+
 #include <cstdint>
 #include <cstdio>
 #include <sys/ioctl.h>
@@ -69,9 +70,15 @@ public:
     // Call to update Console's notion of width and height.
     // Also clears the screen/window.
     void resize();
+
     void update();
+
     uint16_t cursor_row();
+
     uint16_t cursor_column();
+
+public:
+    const char *humanSize(uint64_t bytes, char *output = nullptr, int maxSize = 200);
 
 public:
     void raw(bool on = true);
@@ -113,8 +120,13 @@ public:
     // emit a newline
     void newline(bool erase = true);
 
-    // print a gauge, representing the specified percentage
-    void gauge(int width, double pct, char fill = '>');
+    ///
+    /// print a gauge, representing the specified percentage
+    /// \param width
+    /// \param pct
+    /// \param style 0: none, -1: empty, 1: full
+    ///
+    void gauge(int width, double pct, int style = 0);
 
     void window(int aRow, int aCol, int aWidth, int aHeight, const char *title = "Untitled");
 
@@ -139,8 +151,11 @@ public:
 
 public:
     void default_colors();
+
     void set_colors(uint8_t fg, uint8_t bg);
+
     void set_foreground(uint8_t color);
+
     void set_background(uint8_t color);
 
 public:

--- a/macos/Memory.cpp
+++ b/macos/Memory.cpp
@@ -101,14 +101,26 @@ uint16_t Memory::print(bool newline) const {
                       "  [M]EMORY", "Total", "Used", "Free", "Wired", "Cached");
     count++;
 
-    console.println("  %-12s %'9lld %'9lld %'9lld %'9lld %'9lld",
+#if 0
+    char total[200], used[200], free[200], wired[200], cached[200];
+    console.println("  %-12s %9s %9s %9s %9s %9s",
                     "Real",
-                    this->current.memory_size / 1024 / 1024,
-                    this->current.memory_used / 1024 / 1024, this->current.memory_free / 1024 / 1024,
-                    this->current.wire_count,
-                    this->page_size * (this->current.external_page_count + this->current.purgeable_count) /
-                    1024 /
-                    1024);
+                    console.humanSize(this->current.memory_size, total),
+                    console.humanSize(this->current.memory_used, used),
+                    console.humanSize(this->current.memory_free, free),
+                    console.humanSize(this->current.wire_count, wired),
+                    console.humanSize(this->page_size * (this->current.external_page_count + this->current.purgeable_count)), cached);
+#endif
+    uint64_t cached = page_size * (current.external_page_count + current.purgeable_count);
+    double pct = (double(current.memory_used) - double(cached)) / double(current.memory_size);
+    console.print("  %-12s %'9lld %'9lld %'9lld %'9lld %'9lld ",
+                  "Real",
+                  current.memory_size / 1024 / 1024,
+                  current.memory_used / 1024 / 1024, current.memory_free / 1024 / 1024,
+                  current.wire_count,
+                  page_size * (current.external_page_count + current.purgeable_count) / 1024 / 1024);
+    console.gauge(20, pct*100, 1);
+    console.newline();
     count++;
 
     if (!options.condenseMemory) {

--- a/macos/Platform.cpp
+++ b/macos/Platform.cpp
@@ -218,7 +218,7 @@ uint16_t Platform::print(bool newline) {
     console.print("Battery: ");
     console.mode_clear();
     console.print("%.0f%% ", batteryInfo.chargePct);
-    console.gauge(20, batteryInfo.chargePct);
+    console.gauge(20, batteryInfo.chargePct, -1);
     if (batteryInfo.timeRemaining > 0) {
         console.print(" %.1f hours remaining", batteryInfo.hoursRemaining());
     } else if (batteryInfo.timeRemaining == -1) {

--- a/macos/Processor.cpp
+++ b/macos/Processor.cpp
@@ -226,7 +226,7 @@ void CPU::print() {
 
     renderColor(ndx);
     for (int cnt = 0; cnt < int(use); cnt++) {
-        console.print(">");
+        console.wprintf(L"%lc", 0x25a0);
     }
 
     for (int cnt = 0; cnt < left; cnt++) {

--- a/tools/widechars/Makefile
+++ b/tools/widechars/Makefile
@@ -1,0 +1,8 @@
+OBJ=	main.o
+
+.cc.o:
+	gcc -c -o $*.o $*.cc
+
+widechars: $(OBJ)
+	gcc -o widechars $(OBJ)
+

--- a/tools/widechars/main.cc
+++ b/tools/widechars/main.cc
@@ -1,0 +1,15 @@
+#include <cstdio>
+#include <wchar.h>
+#include <clocale>
+
+int main(int ac, char *av[]) {
+    setlocale(LC_ALL, "");
+  for (wchar_t c = 0x2000; c<0x3000; c++) {
+    wprintf(L"%l04x %lc \n", c, c);
+  }
+
+  wprintf(L"2581 %lc \n", 0x2581);
+
+  return 1;
+}
+


### PR DESCRIPTION
Fixed up gauges, added gauges for battery and memory.

Added tools/widechars tool to print out wide characters.  Used to identify wchar_t values to use for gauges and so on.

Added humanSize() method to Console that fills in, or returns, a buffer with a human readable version of a number.  For example, 1K, 20MB, 30GB, ...

Console::gauge() takes an optional style parameter... If -1, the style of the gauge is like a battery - red if empty, green if not empty, yellow if about half used, 0 = no style, +1 = gauge is like memory - red if used, green if plenty free, yellow if about half used.

